### PR TITLE
Ignore generated file whose line-endings are platform-dependant.

### DIFF
--- a/net.jeeeyul.swtend/.settings/.gitignore
+++ b/net.jeeeyul.swtend/.settings/.gitignore
@@ -1,0 +1,1 @@
+/net.jeeeyul.pdetools.palette.xml

--- a/net.jeeeyul.swtend/.settings/net.jeeeyul.pdetools.palette.xml
+++ b/net.jeeeyul.swtend/.settings/net.jeeeyul.pdetools.palette.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="ASCII"?>
-<p:Palette xmlns:p="http://jeeeyul.net/pde-tools" fieldName="ICONS" folder="/net.jeeeyul.swtend/icons">
-  <imageFiles fieldName="PALETTE" file="/net.jeeeyul.swtend/icons/palette.gif"/>
-  <imageFiles fieldName="PIPETTE_MASK" file="/net.jeeeyul.swtend/icons/pipette-mask.png"/>
-  <imageFiles fieldName="PIPETTE" file="/net.jeeeyul.swtend/icons/pipette.png"/>
-</p:Palette>


### PR DESCRIPTION
The generated XML file has platform-dependent line-endings. This causes spurious unchecked changes to show up in the Git repo on Windows machines when comparing against the master repo with Linux line-endings..
